### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: 🚀 Build, Test and Deploy Hugo
+permissions:
+  contents: read
 # Will trigger the workflow on each push to the main branch
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/rroethof/roethof.net/security/code-scanning/4](https://github.com/rroethof/roethof.net/security/code-scanning/4)

In general, the fix is to add an explicit `permissions` block to the workflow (at the top level) or to the `build` job, setting the minimum required scopes. For this workflow, the steps only read repository contents; they do not push commits, create releases, or modify issues/PRs. Therefore, `contents: read` is sufficient, and can be applied at the workflow root so it covers all jobs.

The best minimal fix without changing behavior is to add a root-level `permissions` section just after the `name` (or after `on:`) in `.github/workflows/main.yml`:

```yaml
name: 🚀 Build, Test and Deploy Hugo
permissions:
  contents: read
```

This constrains the `GITHUB_TOKEN` to read-only repository contents for all jobs that do not override permissions. No imports or other code changes are required. We do not need additional scopes such as `pull-requests` or `issues`, because nothing in the shown job interacts with them.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
